### PR TITLE
Directories are matching the *.js glob and they can't be unlinked, this fixes that

### DIFF
--- a/lib/RuntimeBabel.js
+++ b/lib/RuntimeBabel.js
@@ -270,7 +270,7 @@ module.exports = function(S) {
       S.utils.sDebug('cleaning up');
       return BbPromise
         .fromCallback(cb => require('glob')(`${pathDist}/**/*+(.js|.json)`, {ignore}, cb))
-        .map((filepath) => fs.unlinkAsync(filepath))
+        .map((filepath) => fs.lstatAsync(filepath).then(stats => stats.isFile() && fs.unlinkAsync(filepath)))
         .then(() => S.utils.sDebug('done cleaning up'))
     }
 


### PR DESCRIPTION
bignumber.js is a package included in my node_modules directory. This plugin attempts to call fs.unlinkAsync on this directory because it matches the glob, but this causes it to fail
