### PR TITLE
Don't remove excluded modules from the node modules directory

### DIFF
--- a/lib/RuntimeBabel.js
+++ b/lib/RuntimeBabel.js
@@ -117,7 +117,7 @@ module.exports = function(S) {
         return this.copyFunction(func, pathDist, stage, region)
           .then(() => this._addEnvVarsInline(func, pathDist, stage, region))
           .then(() => this._browserify(func, pathDist))
-          .then(() => this._cleanup(pathDist))
+          .then(() => this._cleanup(func, pathDist))
           .then(() => pathDist);
       });
     }
@@ -259,8 +259,11 @@ module.exports = function(S) {
      * - removes all non-bundled .js and .json files from the pathDist
      */
 
-    _cleanup(pathDist) {
-      let ignore = '**/_serverless_handler.js';
+    _cleanup(func, pathDist) {
+      let exclude = _.get(func, 'custom.runtime').exclude || [],
+        ignore = ['**/_serverless_handler.js']
+          .concat(exclude.map(ex => `${pathDist}/**/node_modules/${ex}/**/*`));
+        
       S.utils.sDebug('cleaning up');
       return BbPromise
         .fromCallback(cb => require('glob')(`${pathDist}/**/*+(.js|.json)`, {ignore}, cb))


### PR DESCRIPTION
I have a solution to this problem I was facing: https://github.com/serverless/serverless-runtime-babel/issues/17

Any module excluded from browserify's bundle is not deleted by the cleapup step.
