### PR TITLE
Add getRemainingTimeInMillis function to context

### DIFF
--- a/lib/babel-runner.js
+++ b/lib/babel-runner.js
@@ -40,7 +40,10 @@ const runFunc = (fn, name, event) => {
       memoryLimitInMB: '1024',
       succeed: resolve,
       fail: reject,
-      done: (err, res) => err ? reject(err) : resolve(res)
+      done: (err, res) => err ? reject(err) : resolve(res),
+      getRemainingTimeInMillis: function() {
+        return 5000;
+      }
     };
 
     try {


### PR DESCRIPTION
The `context` object is being [recreated](https://github.com/serverless/serverless-runtime-babel/blob/master/lib/babel-runner.js#L32) without the `getRemainingTimeInMillis` function, so `sls function run` crashes if it's used in the handler.
