### PR TITLE
Adds callback parameter to ENV loader

### DIFF
--- a/lib/RuntimeBabel.js
+++ b/lib/RuntimeBabel.js
@@ -234,9 +234,9 @@ module.exports = function(S) {
               process.env[key] = envVars[key];
             }
 
-            exports.handler = (event, context) => {
+            exports.handler = (event, context, cb) => {
               try {
-                const result = require('./${handlerFile}')['${handlerMethod}'](event, context);
+                const result = require('./${handlerFile}')['${handlerMethod}'](event, context, cb);
 
                 if (result && typeof result.then == 'function') {
                   result.then(context.succeed).catch(context.fail);


### PR DESCRIPTION
Adds a "cb" parameter to the ENV var pre load handler, allowing callbacks to be used: e.g. of the form `handler (event, context, cb) => {}`.

Had a function looking something like this:

``` javascript
module.exports.handler = (event, context, cb) => {
  console.log(event, context, cb)
  return cb(null, 'Success!');
};
```

Serverless was returning the error 

> cb is not a function

Since it was always undefined. I didn't have the ability to pass a callback through the babel transpiled code, so this change adds that functionality.
